### PR TITLE
Hide ClusterStore methods from generated apidocs

### DIFF
--- a/lib/cluster-store.js
+++ b/lib/cluster-store.js
@@ -54,6 +54,7 @@ module.exports = function(connectOrSession) {
    * @param {Object} options Options for the ClusterStore object.
    * @constructor
    * @extends {session.Store}
+   * @ignore
    */
   function ClusterStore(options) {
     Store.call(this, options);
@@ -70,6 +71,7 @@ module.exports = function(connectOrSession) {
    * @param {Error} err if present, indicates an error condition.
    * @param value The data stored in the collection, could be any type.
    * @end
+   * @ignore
    */
   ClusterStore.prototype.get = function(sid, fn) {
     this._collection.get(sid, fn);
@@ -84,6 +86,7 @@ module.exports = function(connectOrSession) {
    * @callback {Function} fn
    * @param {Error} err If defined, indicates an error occured.
    * @end
+   * @ignore
    */
   ClusterStore.prototype.set = function(sid, session, fn) {
     this._collection.set(sid, session, fn);
@@ -96,7 +99,7 @@ module.exports = function(connectOrSession) {
    * @callback {Function} fn
    * @param {Error} err If defined, indicates an error occured.
    * @end
-   *
+   * @ignore
    */
   ClusterStore.prototype.destroy = function(sid, fn){
     this._collection.del(sid, fn);
@@ -105,7 +108,7 @@ module.exports = function(connectOrSession) {
 
   /**
    * Same as `setup()` (see above).
-   * @private
+   * @ignore
    */
   ClusterStore.setup = setup;
 


### PR DESCRIPTION
Mark all ClusterStore methods as @ignore, so that they don't show up
on apidocs.strongloop.com.

/cc @crandmck 
